### PR TITLE
Changing link example from relative to absolute

### DIFF
--- a/pattern-template/design/overview.md
+++ b/pattern-template/design/overview.md
@@ -1,7 +1,7 @@
 # Pattern Name Goes Here
 
 ## Overview
-This is where you should write the overview description of your pattern contribution. This description should include details such as what makes this pattern useful and when it should be used over other, similar patterns. [Links to related patterns](http://www.patternfly.org/pattern-library/pattern-category/other-pattern/overview.md) are often found on the overview page.
+This is where you should write the overview description of your pattern contribution. This description should include details such as what makes this pattern useful and when it should be used over other, similar patterns. [Links to related patterns](http://www.patternfly.org/pattern-library/pattern-category/other-pattern) are often found on the overview page.
 
 
 ## Examples

--- a/pattern-template/design/overview.md
+++ b/pattern-template/design/overview.md
@@ -1,7 +1,7 @@
 # Pattern Name Goes Here
 
 ## Overview
-This is where you should write the overview description of your pattern contribution. This description should include details such as what makes this pattern useful and when it should be used over other, similar patterns. [Links to related patterns](../pattern-library/other-pattern/other-pattern-design.md) are often found on the overview page.
+This is where you should write the overview description of your pattern contribution. This description should include details such as what makes this pattern useful and when it should be used over other, similar patterns. [Links to related patterns](http://www.patternfly.org/pattern-library/pattern-category/other-pattern/overview.md) are often found on the overview page.
 
 
 ## Examples


### PR DESCRIPTION
## Description
Changes the example link in the pattern-template folder from relative to absolute to conform to our documentation standards

Addresses: #72 

## Changes

- Changes format of example link in overview.md file



