### PR TITLE
Resolving bug #240 : replacing "Card view" with "List view" and making…

### DIFF
--- a/pattern-library/content-views/list-view/design/design.md
+++ b/pattern-library/content-views/list-view/design/design.md
@@ -53,4 +53,4 @@
 
 - **Vertical Scroll:** Use a vertical scrollbar as needed. A horizontal scrollbar should NOT be used. Instead, the page containing the List View should be responsive.
 
-- **Pagination:** Card view can also support pagination. See [Pagination](https://github.com/patternfly/patternfly-design/tree/master/pattern-library/navigation/pagination/design) for more details.
+- **Pagination:** List view can also support pagination. See [Pagination](http://www.patternfly.org/pattern-library/navigation/pagination/) for more details.


### PR DESCRIPTION
Fixing bug #240.

## Description
Replacing "Card view" with "List view", and making the Pagination link go to the pattern on the site, not github.

## Changes

Write a list of changes the PR introduces

For the line "Pagination: Card view can also support pagination. See Pagination for more details." on http://www.patternfly.org/pattern-library/content-views/list-view/#/design:

* Replaced "Card view" with "List view" to reflect the fact that this is the list view page.
* Updated the "Pagination" link to go to the pattern on the site (http://www.patternfly.org/pattern-library/navigation/pagination/) rather than to the respective github link.