### PR TITLE
Pagination needs to point to within the pattern library, not github.

### DIFF
--- a/pattern-library/content-views/card-view/design/design.md
+++ b/pattern-library/content-views/card-view/design/design.md
@@ -29,4 +29,4 @@
 
 - **Vertical Scroll:** Use a vertical scrollbar as needed. A horizontal scrollbar should NOT be used. Instead, the page containing the Card View should be responsive.
 
-- **Pagination:** Card view can also support pagination. See [Pagination](https://github.com/patternfly/patternfly-design/tree/master/pattern-library/navigation/pagination/design) for more details.
+- **Pagination:** Card view can also support pagination. See [Pagination](http://www.patternfly.org/pattern-library/navigation/pagination/) for more details.

--- a/pattern-library/content-views/table-view/design/design.md
+++ b/pattern-library/content-views/table-view/design/design.md
@@ -72,4 +72,4 @@
 
 ## Additional Notes about Behavior
 
-- **Pagination:** Table view supports pagination. See [Pagination](https://github.com/patternfly/patternfly-design/tree/master/pattern-library/navigation/pagination/design) for more details.
+- **Pagination:** Table view supports pagination. See [Pagination](http://www.patternfly.org/pattern-library/navigation/pagination/) for more details.


### PR DESCRIPTION
## Description
Pagination was linked to github, rather than the pattern library.

## Changes

Write a list of changes the PR introduces

* Replaced the github link with http://www.patternfly.org/pattern-library/navigation/pagination/