### PR TITLE
Corrected the toast-notification angular example

### DIFF
--- a/pattern-library/communication/toast-notifications/site.md
+++ b/pattern-library/communication/toast-notifications/site.md
@@ -3,5 +3,5 @@ layout: page-pattern
 overview: pattern-library/communication/toast-notifications/design/overview.md
 design: pattern-library/communication/toast-notifications/design/design.md
 code_html: code/communication/toast-notifications/code.md
-code_angular: /components/angular-patternfly/dist/docs/partials/api/patternfly.notification.directive.pfInlineNotification.html
+code_angular: /components/angular-patternfly/dist/docs/partials/api/patternfly.notification.directive.pfToastNotification.html
 ---


### PR DESCRIPTION
This PR fixes this bug:
> Toast notifications AngularJS example is showing inline notifications instead
https://github.com/patternfly/patternfly-org/issues/401