### PR TITLE
Fixing the Terminology and Wording part of ticket #245.

### DIFF
--- a/styles/terminology-and-wording/terminology-and-wording.md
+++ b/styles/terminology-and-wording/terminology-and-wording.md
@@ -84,13 +84,14 @@ For sentence style, capitalize the first letter of the first word and any proper
 | Group headings, group boxes                                | Headline       |
 | List boxes: Introductory text                              | Sentence       |
 | List boxes: List box labels                                | Headline       |
+| Menu items                                                 | Headline       |
 | Prompts                                                    | Sentence       |
 | Radio buttons labels                                       | Sentence       |
 | States (as shown in tables, filters, e. g. Up and Running) | Headline       |
 | Status messages                                            | Sentence       |
 | Tab labels                                                 | Headline       |
 | Text box labels                                            | Headline       |
-| Tooltips                                                  | Sentence       |
+| Tooltips                                                   | Sentence       |
 | Window titles (browsers, dialog boxes, steps in a wizard)  | Headline       |
 
 ## Links


### PR DESCRIPTION
## Description
Adding a line to the Capitalization table for Menu items, so that it's clear they should be Headline style.

Fixes ticket #245.

## Changes

* New line in the table for Menu items, between L and P (as it appeared to be alphabetical)
* Added a space to Tooltips so it lined up with everything else in the table.