### PR TITLE
Adding the missing fa-icons

### DIFF
--- a/styles/icons/fontawesome.md
+++ b/styles/icons/fontawesome.md
@@ -20,6 +20,7 @@
 | <span class="fa fa-cube"></span>                       | fa-cube                   |                 |
 | <span class="fa fa-cubes"></span>                      | fa-cubes                  |                 |
 | <span class="fa fa-database"></span>                   | fa-database               |                 |
+| <span class="fa fa-ellipsis-v"></span>                 | fa-ellipsis-v             |                 |
 | <span class="fa fa-envelope"></span>                   | fa-envelope               |                 |
 | <span class="fa fa-filter"></span>                     | fa-filter                 |                 |
 | <span class="fa fa-list-alt"></span>                   | fa-list-alt               |                 |
@@ -32,6 +33,8 @@
 | <span class="fa fa-refresh"></span>                    | fa-refresh                |                 |
 | <span class="fa fa-search"></span>                     | fa-search                 |                 |
 | <span class="fa fa-shield"></span>                     | fa-shield                 |                 |
+| <span class="fa fa-sort-alpha-asc"></span>             | fa-sort-alpha-asc         |                 |
+| <span class="fa fa-sort-alpha-desc"></span>            | fa-sort-alpha-desc        |                 |
 | <span class="fa fa-sort-asc"></span>                   | fa-sort-asc               |                 |
 | <span class="fa fa-sort-desc"></span>                  | fa-sort-desc              |                 |
 | <span class="fa fa-sort"></span>                       | fa-sort                   |                 |


### PR DESCRIPTION
Adding the missing List View Vertical Ellipsis icon and Toolbar Sort icon.

## Description
In the icon pattern page, missing the List View Vertical Ellipsis icon and Toolbar Sort icon which used in the [list page](http://www.patternfly.org/pattern-library/content-views/list-view/list-view.html). this issue also has been mentioned in here: https://github.com/patternfly/patternfly-org/issues/416

(optional) Include related PRs, Issues and or Jira stories.
https://github.com/patternfly/patternfly-org/issues/416

Before vs After in the patternfly website - Icon http://www.patternfly.org/styles/icons/
![icons](https://user-images.githubusercontent.com/701009/27281780-e6c1b1fc-551f-11e7-8850-413b4fbbf9fc.png)
p.s: "New" is just for marking which is new, it won't be displayed in the website. :-)