### PR TITLE
Terminology and wording updates for "Log out"

### DIFF
--- a/pattern-library/application-framework/masthead/design/design.md
+++ b/pattern-library/application-framework/masthead/design/design.md
@@ -23,7 +23,7 @@ The masthead contains the following items from left to right:
   8. **User Icon:**
      * The username of the current logged in user should be listed to the right of the pficon-user icon and should always be in the top right corner of the masthead.
      * The dropdown arrow should appear to the right of the name to indicate additional options below.
-     * The dropdown items may vary based on the user settings and permissions available, but this section should always include a "Logout" option at the bottom of the dropdown list.
+     * The dropdown items may vary based on the user settings and permissions available, but this section should always include a "Log out" option at the bottom of the dropdown list.
      * If a [Language Selector](https://www.patternfly.org/pattern-library/forms-and-controls/language-selector/#/api) exists, it should appear in this dropdown menu as well.
 
 

--- a/styles/terminology-and-wording/terminology-and-wording.md
+++ b/styles/terminology-and-wording/terminology-and-wording.md
@@ -13,7 +13,8 @@
 ## Common Terms and Words
 
 - Login (adj): As in a Login page. It also could be use as a noun as another name for username. However, "username" is recommended.
-- Log in (v): Use "Log In" as the button label for the Login page.
+- Log in (v): Use "Log in" ato describe the action of loggin in. An example of this is seen on the button label for the Login page.
+- Log out (v): Use "Log out" as the to describe the action of logging out.
 - Username (n): Usually a unique ID (e.g. ssmith123). Use "username" for the product login screen.
 
 ### Terminology and Wording for Action Labels


### PR DESCRIPTION
## Changes

* updating documentation to fix “logout” to “log out” on the masthead pattern 
* adding “log out” definition to the t&w page.

