### PR TITLE
Includes page parameter to show app launcher in nav

### DIFF
--- a/pattern-library/application-framework/launcher/site.md
+++ b/pattern-library/application-framework/launcher/site.md
@@ -3,6 +3,7 @@ layout: page-pattern
 overview: pattern-library/application-framework/launcher/design/overview.md
 design: pattern-library/application-framework/launcher/design/design.md
 code_html: code/application-framework/launcher/code.md
+applauncher: true
 code_angular: /components/angular-patternfly/dist/docs/partials/api/patternfly.navigation.component.pfApplicationLauncher.html
 impl_jquery: https://rawgit.com/patternfly/patternfly/master-dist/dist/tests/application-launcher.html
 impl_angular: http://www.patternfly.org/angular-patternfly/#/api/patternfly.navigation.component:pfApplicationLauncher


### PR DESCRIPTION
## Description
* Fixes the second issue described in the [app launcher patternfly-org issue](https://github.com/patternfly/patternfly-org/issues/451)
* A fix for the first issue is included in [PR 453 in patternfly-org](https://github.com/patternfly/patternfly-org/pull/453)

## Changes

* The [horizontal](https://github.com/patternfly/patternfly/blob/master/tests/pages/_includes/widgets/navigation/horizontal-primary-nav-bar.html#L15) and [vertical](https://github.com/patternfly/patternfly/blob/master/tests/pages/_includes/widgets/layouts/navbar-vertical.html#L15) navigation includes that are used on the pattern page for the app launcher require a page parameter `applauncher: true` in order for the app launcher to display in the navigation. I included this page parameter in the site.md file for this pattern, so the app launcher icon should now display in this example on patternfly.org.

