### PR TITLE
The 'url-js-extra' front matter attribute needs to be an array

### DIFF
--- a/pattern-library/communication/empty-state/site.md
+++ b/pattern-library/communication/empty-state/site.md
@@ -4,7 +4,7 @@ overview: pattern-library/communication/empty-state/design/overview.md
 design: pattern-library/communication/empty-state/design/design.md
 code_html: code/communication/empty-state/code.md
 code_angular: /components/angular-patternfly/dist/docs/partials/api/patternfly.views.component.pfEmptyState.html
-url-js-extra: components/angular-patternfly/dist/docs/grunt-scripts/angular-drag-and-drop-lists.js
+url-js-extra: ['components/angular-patternfly/dist/docs/grunt-scripts/angular-drag-and-drop-lists.js']
 impl_jquery: https://rawgit.com/patternfly/patternfly/master-dist/dist/tests/blank-slate.html
 impl_angular: https://www.patternfly.org/angular-patternfly/#/api/patternfly.views.component:pfEmptyState
 impl_ng: https://rawgit.com/patternfly/patternfly-ng/master-dist/dist-demo/#/emptystate


### PR DESCRIPTION
## Description
The 'url-js-extra' front matter attribute in empty-state site.md file needs to be an array. This PR is targeted to the issue https://github.com/patternfly/patternfly-design/issues/416