### PR TITLE
Enhancements to the Toast Notifications pattern to....

### DIFF
--- a/pattern-library/communication/toast-notifications/design/design.md
+++ b/pattern-library/communication/toast-notifications/design/design.md
@@ -2,6 +2,8 @@
 
 ![Toast notifications with callouts](img/toast-callout.png)
 
+It is recommended that Toast Notifications are transient and stay on the screen for 8 seconds. That way, they do not block the information for an extended amount of time, but allows the user to read the message. All Toast Notifications should remain on the screen when the user is hovering over one of them. Ideally, the user can decide what kinds of notifications appear and how long they remain on the screen. The notifications should have a consistent location in each application. We recommend the top-right of the application, underneath the [Masthead](http://www.patternfly.org/pattern-library/application-framework/masthead/).
+
 1. **Icon:** Indicates the type of notification displayed (e.g. info, success, warning or error).
 
 1. **Message:** The message should explain what just happened and what the user needs to perform next. Do not include any unnecessary text. Ideally, the message is no longer than one line. Bold the important information (e.g. the names of relevant objects).

--- a/pattern-library/communication/toast-notifications/design/overview.md
+++ b/pattern-library/communication/toast-notifications/design/overview.md
@@ -1,8 +1,6 @@
 # Toast Notifications
 
-Toast Notifications pop onto the screen to notify the user of a system occurrence. The notifications should have a consistent location in each application. We recommend the top-right of the application. It should include a message list that enables the user to view messages later.
-
-Toast Notifications should be transient and stay on the screen for 8 seconds, so that they do not block the information behind them for too long, but allows the user to read the message. Ideally, the user can decide what kinds of notifications appear and how long they remain on the screen. Toast Notifications should remain on the screen when the user is hovering on them.
+Toast Notifications notify the user of a system occurrence. The notifications should have a consistent location in each application. We recommend the top-right of the application. The [Notification Drawer](http://www.patternfly.org/pattern-library/communication/notification-drawer/) can be used in conjunction with Toast Notifications to allow the user to view messages later.
 
 
 ![Toast Notification](img/toast-notification.png)


### PR DESCRIPTION
- Moved specific behavior information from Overview to Design
- Included information about behavior on hover (all toasts should remain on the screen)
- Updated information about toast notification to specify that lives under the masthead
- Added references and links to related patterns, Masthead and Notification drawer
- General text clean-up

Closes #423 
Closes #408  