### PR TITLE
fix-bug: angularjs code tab of canvas view is blank

### DIFF
--- a/pattern-library/content-views/canvas-view/site.md
+++ b/pattern-library/content-views/canvas-view/site.md
@@ -2,8 +2,9 @@
 layout: page-pattern
 overview: pattern-library/content-views/canvas-view/design/overview.md
 design: pattern-library/content-views/canvas-view/design/design.md
-code_angular: /components/angular-patternfly/dist/docs/partials/api/patternfly.canvas.directive.pfCanvas.html
+code_angular: /components/angular-patternfly/dist/docs/partials/api/patternfly.canvas.component.pfCanvasEditor.html
 url-js-extra: [
+ 'components/angular-patternfly/dist/docs/grunt-scripts/jquery-ui.min.js',
  'components/angular-patternfly/dist/docs/grunt-scripts/angular-dragdrop.js',
  'components/angular-patternfly/dist/docs/grunt-scripts/angular-drag-and-drop-lists.js'
  ]


### PR DESCRIPTION
## Description
* show the code and demo of angular canvas view under the code tab.  
* This PR is targeted to fix the [issue](https://github.com/patternfly/patternfly-design/issues/449).

