### PR TITLE
Normalize how we present (optional) in list items and headers

### DIFF
--- a/pattern-library/cards/base-card/design/design.md
+++ b/pattern-library/cards/base-card/design/design.md
@@ -4,13 +4,13 @@
 ![Image of blank card](img/card.png)
 
 1. **Background and Borders:** All cards in a dashboard or content view should have the same background and border treatment.
-1. **Top Accent** (optional)**:** Add a top accent to a row of cards to give them visual hierarchy.
+1. **Top Accent** (optional): Add a top accent to a row of cards to give them visual hierarchy.
 
 ## Titles
 ![Image of card title](img/card-title-and-subtitle.png)
 
-1. **Title** (optional)**:** If the content of the card is not obvious, add a title to clarify what information is being presented. The title is always followed by a horizontal separator.
-1. **Subtitle** (optional)**:** Add a subtitle if the card contains the same visualization for different object types.
+1. **Title** (optional): If the content of the card is not obvious, add a title to clarify what information is being presented. The title is always followed by a horizontal separator.
+1. **Subtitle** (optional): Add a subtitle if the card contains the same visualization for different object types.
 
 ## Time Frame Filter (optional)
 ![Image of time frame filter placement options](img/card-timeframe.png)
@@ -23,9 +23,9 @@ There are two options for where the time frame filter may be placed:
 ## Actions Panel (optional)
 ![Image of card actions panel](img/card-actionspanel.png)
 
-1. **Actions Panel** (optional)**:** Include an actions panel at the bottom of the card if there is a primary action that you would like the user to quickly and easily be able to access from the card view.
-1. **Actions Icon** (optional)**:** Include an associated icon with the action button if applicable.
-1. **Flat Actions Button** (optional)**:** Within an actions panel you should have an action represented as a flat button on the left.
+1. **Actions Panel** (optional): Include an actions panel at the bottom of the card if there is a primary action that you would like the user to quickly and easily be able to access from the card view.
+1. **Actions Icon** (optional): Include an associated icon with the action button if applicable.
+1. **Flat Actions Button** (optional): Within an actions panel you should have an action represented as a flat button on the left.
 
 ## Loading
 ![Image of loading state](img/card-loading.png)

--- a/pattern-library/cards/trend-card/design/design.md
+++ b/pattern-library/cards/trend-card/design/design.md
@@ -16,7 +16,7 @@
 
       - Right of the sparkline
 
-  1. **Total Value** (optional)**:**
+  1. **Total Value** (optional):
     If needed, provide total value next to the actual value to help provide context.
 
   1. **Unit of Measurement:**
@@ -28,7 +28,7 @@
   1. **Tooltip:**
     Use a tooltip on hover to display additional information about exact points on the sparkline (e.g. values and/or percentages). A vertical line and marker helps to accentuate the hover point.
 
-  1. **Time Frame** (optional)**:** The time frame on a card is optional since there could be a single instance of the time frame label or time frame filter that applies to all cards within a single view. The time frame is indicated by placing a label on one of the following areas:
+  1. **Time Frame** (optional): The time frame on a card is optional since there could be a single instance of the time frame label or time frame filter that applies to all cards within a single view. The time frame is indicated by placing a label on one of the following areas:
 
       - Under the title
 
@@ -36,7 +36,7 @@
       
       - In a [Time Frame Filter](http://www.patternfly.org/pattern-library/cards/base-card/#/design#time-frame-filter-optional)
 
-  1. **Actions Panel** (optional)**:**
+  1. **Actions Panel** (optional):
     See [Actions Panel](http://www.patternfly.org/pattern-library/cards/base-card/#/design#actions-panel-optional) under the Cards pattern for more details.
 
 ## Card with Multiple Trends
@@ -55,13 +55,13 @@
   1. **Actual Value:**
     Shows the current value to the right of the sparkline.
 
-  1. **Total Value** (optional)**:**
+  1. **Total Value** (optional):
     If needed, provide total value next to the actual value to help provide context.
 
   1. **Unit of Measurement:**
     The label for unit of measurement is shown after the the value.
 
-  1. **Percentage** (optional)**:**
+  1. **Percentage** (optional):
     The location of the percentage can be shown to the right of the sparkline.
 
   1. **Sparkline:**

--- a/pattern-library/cards/utilization-trend-card/design/design.md
+++ b/pattern-library/cards/utilization-trend-card/design/design.md
@@ -19,7 +19,7 @@
 
   1. **Sparkline:** See the [Sparkline Pattern](https://www.patternfly.org/pattern-library/data-visualization/sparkline/) for more details.
 
-  1. **Time Frame** (optional)**:** The time frame is indicated under the sparkline by small text and is left aligned.
+  1. **Time Frame** (optional): The time frame is indicated under the sparkline by small text and is left aligned.
 
 ## Card with Multiple Metrics
 ![Multiple Metrics Card](img/multi-metric-utilization-card-callout1.png)

--- a/pattern-library/communication/empty-state/design/design.md
+++ b/pattern-library/communication/empty-state/design/design.md
@@ -4,8 +4,8 @@
 
 ![Empty State with Callouts](img/empty-state.png)
 
-1. **Icon** (optional)**:** If an object icon is associated with this view, it can be displayed here.
+1. **Icon** (optional): If an object icon is associated with this view, it can be displayed here.
 1. **Empty State Title:** Give it a name.
-1. **Text** (optional)**:** This text should be personal and helpful. It should minimize the user’s effort to complete tasks.
+1. **Text** (optional): This text should be personal and helpful. It should minimize the user’s effort to complete tasks.
 1. **Primary Action Button:** The primary action is displayed as a prominent blue button. See the [Action Labels](http://www.patternfly.org/styles/terminology-and-wording/#action-labels) section for more information about terminology and wording specific to action labels.
-1. **Secondary Action Buttons** (optional)**:** Secondary actions are alternative options for the user. They are shown as more subtle gray buttons and located below the main action. There can be more than one secondary action.
+1. **Secondary Action Buttons** (optional): Secondary actions are alternative options for the user. They are shown as more subtle gray buttons and located below the main action. There can be more than one secondary action.

--- a/pattern-library/communication/notification-drawer/design/design.md
+++ b/pattern-library/communication/notification-drawer/design/design.md
@@ -20,8 +20,8 @@ Jump to [Toast Notification](#toast-notification), [Notification Drawer](#notifi
   - New/unread notifications are shown in bold.
   - Clicking on a row will remove the bold text and the item will be marked as "read."
 5. **Row Hover State:** Example of hover state.
-6. **Mark All Read** (Optional): Clicking “Mark All Read” changes all visible unread rows (bold row type) to read (regular row type).
-7. **Clear All** (Optional): Clicking “Clear All” removes all visible rows from the drawer.
+6. **Mark All Read** (optional): Clicking “Mark All Read” changes all visible unread rows (bold row type) to read (regular row type).
+7. **Clear All** (optional): Clicking “Clear All” removes all visible rows from the drawer.
   - Note: This option may be used differently across products.
   - Some rows may not be eligible for clearing and should be determined on a case by case basis.
   - This link may be hidden as needed.
@@ -30,7 +30,7 @@ Jump to [Toast Notification](#toast-notification), [Notification Drawer](#notifi
 10. **Row Actions:** Clicking on the [Kebab](https://www.patternfly.org/pattern-library/widgets/#kebabs) menu will reveal a dropdown containing actions for that item.
 11. **Infinite Scroll:** Allows the user to scroll through all notifications in the drawer viewport.
 
-## Expand Behavior (Optional)
+## Expand Behavior (optional)
 The notification drawer has the ability to expand in order to view additional details regarding an event. The expand drawer functionality is optional. Use of this feature will depend on the amount of information available.
 
 ### Collapsed Drawer

--- a/pattern-library/forms-and-controls/drag-and-drop/design/design.md
+++ b/pattern-library/forms-and-controls/drag-and-drop/design/design.md
@@ -12,7 +12,7 @@
   * When a user hovers over the handle icon, the cursor should change to an open hand, signifying the item can be dragged.
   * (Optional) If you choose to display the handle icon on unselected rows as well, the icon should appear visually disabled so it does not distract from the content.
 
-3. **Item Sequence (Optional):**
+3. **Item Sequence** (optional): 
   * If the order of items is important, the order number should be clearly labeled.
   * When an item is being moved, the order numbers should not change to reflect the move until the item has been successfully dropped in a new location.
 
@@ -31,7 +31,7 @@
   * The handle icon should not be used when applying drag and drop to horizontal lists, card views, or dashboards.
   * When a user hovers over an item or selects an item (anywhere that is not already a link, checkbox, button, etc), it should be visually indicated and the cursor should change to an open hand, signifying this item can be moved.
 
-2. **Multi-Selection (Optional):**
+2. **Multi-Selection** (optional):
   * If multi-selection is being supported, checkboxes should be used for moving multiple items at once.
   * Dragging multiple checked items will move the items as a group and will place them consecutively when dropped in the list.
 

--- a/pattern-library/forms-and-controls/dual-pane-selector/DualPaneSelector.md
+++ b/pattern-library/forms-and-controls/dual-pane-selector/DualPaneSelector.md
@@ -13,11 +13,11 @@ Dual Pane Selectors allow users to visually compare available and selected items
   1. **Type-ahead Filter**
     - Type-ahead filter allows you to easily reduce long lists to more quickly find items.
 
-  1. **Sorting (optional)**
+  1. **Sorting** (optional):
     - Default sort will be alphabetical.
     - Additional sorting options are dependent on the data.
 
-  1. **Additional Actions (optional)**
+  1. **Additional Actions** (optional):
       - Additional actions can be presented as a button.
       - More than one action should be presented in a kebab.
 

--- a/pattern-library/forms-and-controls/modal-overlay/design/design.md
+++ b/pattern-library/forms-and-controls/modal-overlay/design/design.md
@@ -2,7 +2,7 @@
 
 ![Image of Overlay 3](img/Overlay-02.png)
 
-1. **Title** (Optional): There should be a title bar spanning the top of the modal with a title in the top left corner. The title should be descriptive enough to convey the purpose of the modal while remaining concise. The title may match the action button or link that prompted the overlay modal to appear.
+1. **Title** (optional): There should be a title bar spanning the top of the modal with a title in the top left corner. The title should be descriptive enough to convey the purpose of the modal while remaining concise. The title may match the action button or link that prompted the overlay modal to appear.
 
 2. **Close:** The pficon-close icon should always be available in the top right corner to close the modal overlay.
 

--- a/pattern-library/forms-and-controls/slider/design/design.md
+++ b/pattern-library/forms-and-controls/slider/design/design.md
@@ -12,16 +12,16 @@
 
 3. **Tooltip:** The current value should be displayed in a tooltip when users hover or click on the slider handle.
 
-4. **Numeric Scale** (Optional):
+4. **Numeric Scale** (optional):
   - A numeric scale may be displayed below the slider.
   - Displaying a numeric scale is recommended when using a discrete slider that snaps to specific values.
   - Note: The scale is not required to denote ALL discrete values.  
 
-5. **Discrete Values** (Optional): When using a discrete scale, each available value may be indicated using marks along the slider. The marks make it clear to users when the slider will snap to specific values.
+5. **Discrete Values** (optional): When using a discrete scale, each available value may be indicated using marks along the slider. The marks make it clear to users when the slider will snap to specific values.
 
-6. **Field Input** (Optional): The slider can optionally have a field input on the right side to enter the desired value as an alternative to sliding. The slider button should move to indicate the value entered.
+6. **Field Input** (optional): The slider can optionally have a field input on the right side to enter the desired value as an alternative to sliding. The slider button should move to indicate the value entered.
 
-7. **Unit Dropdown** (Optional): A dropdown may be provided in conjunction with the field input if various units are available for selection.
+7. **Unit Dropdown** (optional): A dropdown may be provided in conjunction with the field input if various units are available for selection.
 
 ## Slider Examples
 ![Image of Slider 3](img/Slider-03.png)

--- a/pattern-library/navigation/breadcrumbs/design/design.md
+++ b/pattern-library/navigation/breadcrumbs/design/design.md
@@ -15,12 +15,12 @@
 ![Horizontal Navigation Example](img/Breadcrumbs-04.png)
 When secondary navigation items are hidden, breadcrumbs may be used in conjunction with horizontal navigation.
 
-## Breadcrumbs Combined with Page Title (Optional)
+## Breadcrumbs Combined with Page Title (optional)
 ![Example with Optional Page Title ](img/Breadcrumbs-05.png)
 
 1. **Current Location:** The end of the breadcrumb can also play the role of page title in an effort to conserve vertical space. This option would include use of a larger font for the end of the breadcrumb string. If this format is used, it should be used consistently throughout the application.
 
-## Breadcrumb Switcher (Optional)
+## Breadcrumb Switcher (optional)
 The Breadcrumb Switcher provides a shortcut for users to quickly navigate to parallel pages, rather than navigating back to the previous page and making a new selection. In the example below, users can either go back to the "Packages" page to select a new item or they can remain in the details view shown, and use the switcher to jump from one item to the next. The switcher should never appear in the middle of the breadcrumbs. When used, the switcher will appear to the right of the last item in the breadcrumb string. 
 
 ![Switcher](img/switcher.png)
@@ -28,7 +28,7 @@ The Breadcrumb Switcher provides a shortcut for users to quickly navigate to par
 1. **Icon:** The "fa-exchange" Font Awesome icon should be placed on a button to the right of the breadcrumb string, allowing users to access the Switcher.
 2. **Dropdown List:** Clicking the switcher button should open a panel with the list of items parallel to the one displayed on the current page. When an item is selected from the list, users will be navigated to a new page.
 3. **Selected State:** The selected state should be visually indicated in the list.
-4. **Search** (Optional):
+4. **Search** (optional):
   - A search bar can be available at the top of the dropdown list with the "fa-search" icon on the left side of the bar.
   - Searching will allow users to narrow down the list of results to display only matching items.
   - The matching piece of the results should appear in bold text.

--- a/pattern-library/navigation/vertical-navigation/design/design.md
+++ b/pattern-library/navigation/vertical-navigation/design/design.md
@@ -31,7 +31,7 @@ Tertiary navigation is non-persistent and only appears on hover. The tertiary na
 
 ![navigation-with-tertiary-callout](img/navigation-with-tertiary-callout.png)
 
-1. **Pin Menu**(optional):
+1. **Pin Menu** (optional):
   - If the secondary navigation is pinned, the navigation is collapsed to a single column and the secondary navigation is the only menu visible.
   - If the tertiary navigation is pinned, the navigation is collapsed to a single column and the tertiary navigation is the only menu visible.
 2. **Label**:


### PR DESCRIPTION
* make sure (optional) is lower case.
* if it's associated with the bold beginning of a list item, make sure it, and the comma that follows, are not bold.