### PR TITLE
Updating site.md for missing code examples

### DIFF
--- a/pattern-library/application-framework/single-sign-on/site.md
+++ b/pattern-library/application-framework/single-sign-on/site.md
@@ -2,6 +2,6 @@
 layout: page-pattern
 overview: pattern-library/application-framework/single-sign-on/design/overview.md
 design: pattern-library/application-framework/single-sign-on/design/design.md
-code: false
+code_html: code/application-framework/single-sign-on/code.md
 impl_jquery: https://rawgit.com/patternfly/patternfly/master-dist/dist/tests/login-single-sign-on.html
 ---

--- a/pattern-library/communication/experimental-features/site.md
+++ b/pattern-library/communication/experimental-features/site.md
@@ -2,6 +2,6 @@
 layout: page-pattern
 overview: pattern-library/communication/experimental-features/design/overview.md
 design: pattern-library/communication/experimental-features/design/design.md
-code: false
+code_html: code/communication/experimental-features/code.md
 impl_jquery: https://rawgit.com/patternfly/patternfly/master-dist/dist/tests/experimental-features.html
 ---

--- a/pattern-library/forms-and-controls/modal-overlay/site.md
+++ b/pattern-library/forms-and-controls/modal-overlay/site.md
@@ -2,6 +2,7 @@
 layout: page-pattern
 overview: pattern-library/forms-and-controls/modal-overlay/design/overview.md
 design: pattern-library/forms-and-controls/modal-overlay/design/design.md
-code_html: false
+code_html: code/forms-and-controls/modal-overlay/code.md
+impl_jquery: https://rawgit.com/patternfly/patternfly/master-dist/dist/tests/modals.html
 impl_react: https://rawgit.com/patternfly/patternfly-react/gh-pages/index.html?knob-Right%20aligned=false&knob-fluid=true&knob-Stacked=false&selectedKind=Modal%20Overlay&selectedStory=Modal
 ---

--- a/pattern-library/forms-and-controls/textbox-filter/site.md
+++ b/pattern-library/forms-and-controls/textbox-filter/site.md
@@ -2,7 +2,7 @@
 layout: page-pattern
 overview: pattern-library/forms-and-controls/textbox-filter/design/overview.md
 design: pattern-library/forms-and-controls/textbox-filter/design/design.md
-code_html: false
+code_html: code/forms-and-controls/textbox-filter/code.md
 impl_jquery: https://rawgit.com/patternfly/patternfly/master-dist/dist/tests/filter.html
 impl_angular: https://www.patternfly.org/angular-patternfly/#/api/patternfly.filters.component:pfFilter
 impl_ng: https://rawgit.com/patternfly/patternfly-ng/master-dist/dist-demo/#/filters


### PR DESCRIPTION
## Description
Related to this jira story:  https://patternfly.atlassian.net/browse/PTNFLY-2783
and this recently merged PR: https://github.com/patternfly/patternfly-org/pull/528

## Changes

Updated site.md to enable code tab to display experimental features, modal overlay, textbox-filter and single-sign-on on pf-org

Experimental Features: [here](https://rawgit.com/amarie401/patternfly-org/missing-code-examples-dist/_site/pattern-library/communication/experimental-features/#code)

Single Sign On: [here](https://rawgit.com/amarie401/patternfly-org/missing-code-examples-dist/_site/pattern-library/application-framework/single-sign-on/#code)

Textbox Filter: [here](https://rawgit.com/amarie401/patternfly-org/missing-code-examples-dist/_site/pattern-library/forms-and-controls/textbox-filter/#code)

Modal Overlay: [here](https://rawgit.com/amarie401/patternfly-org/missing-code-examples-dist/_site/pattern-library/forms-and-controls/modal-overlay/#code)