### PR TITLE
 Adding field level help to help on forms example

### DIFF
--- a/pattern-library/forms-and-controls/field-labeling/site.md
+++ b/pattern-library/forms-and-controls/field-labeling/site.md
@@ -2,7 +2,7 @@
 layout: page-pattern
 overview: pattern-library/forms-and-controls/field-labeling/design/overview.md
 design: false
-code_html: code/forms-and-controls/field-level-help/code.md
+code_html: false
 impl_jquery: https://rawgit.com/patternfly/patternfly/master-dist/dist/tests/forms.html#right-aligned
 impl_react: https://rawgit.com/patternfly/patternfly-react/gh-pages/index.html?knob-Show%20Modal=true&selectedKind=Forms&selectedStory=Horizontal%20Form
 ---

--- a/pattern-library/forms-and-controls/help-on-forms/site.md
+++ b/pattern-library/forms-and-controls/help-on-forms/site.md
@@ -2,6 +2,6 @@
 layout: page-pattern
 overview: pattern-library/forms-and-controls/help-on-forms/design/overview.md
 design: pattern-library/forms-and-controls/help-on-forms/design/design.md
-code_html: false
+code_html: code/forms-and-controls/field-level-help/code.md
 impl_react: https://rawgit.com/patternfly/patternfly-react/gh-pages/index.html?knob-Show%20Modal=true&selectedKind=Forms&selectedStory=Horizontal%20Form
 ---


### PR DESCRIPTION
## Description
Fixing error from last PR here: https://github.com/patternfly/patternfly-design/pull/616


## Changes

Write a list of changes this design pattern introduces

* Adding field level help to help on forms example instead of field-labeling

