### PR TITLE
Updating framework links for status page and pf-org

### DIFF
--- a/pattern-library/communication/notification-drawer/site.md
+++ b/pattern-library/communication/notification-drawer/site.md
@@ -8,5 +8,5 @@ code_angular: /components/angular-patternfly/dist/docs/partials/api/patternfly.n
 url-js-extra: ['components/angular-patternfly/dist/docs/grunt-scripts/angular-drag-and-drop-lists.js']
 impl_jquery: https://rawgit.com/patternfly/patternfly/master-dist/dist/tests/notification-drawer-vertical-nav.html
 impl_angular: https://www.patternfly.org/angular-patternfly/#/api/patternfly.notification.component:pfNotificationDrawer
-impl_webcomponent: https://rawgit.com/patternfly-webcomponents/patternfly-webcomponents/master-dist/app/app.html?dir=pf-notification-drawer&file=index.html
+impl_react: https://rawgit.com/patternfly/patternfly-react/gh-pages/index.html?selectedKind=NotificationDrawer&selectedStory=Notification%20Drawer
 ---

--- a/pattern-library/data-visualization/utilization-bar-chart/site.md
+++ b/pattern-library/data-visualization/utilization-bar-chart/site.md
@@ -6,5 +6,5 @@ code_html: code/data-visualization/utilization-bar-chart/code.md
 code_angular: /components/angular-patternfly/dist/docs/partials/api/patternfly.charts.directive.pfUtilizationBarChart.html
 impl_jquery: https://rawgit.com/patternfly/patternfly/master-dist/dist/tests/utilization-bar-charts.html
 impl_angular: https://www.patternfly.org/angular-patternfly/#/api/patternfly.charts.directive:pfUtilizationBarChart
-impl_webcomponent: https://rawgit.com/patternfly-webcomponents/patternfly-webcomponents/master-dist/app/app.html?dir=pf-utilization-bar-chart&file=index.html
+impl_react: https://rawgit.com/patternfly/patternfly-react/gh-pages/index.html?&selectedKind=UtilizationBar&selectedStory=Utilization%20Bar
 ---

--- a/pattern-library/forms-and-controls/inline-edit/site.md
+++ b/pattern-library/forms-and-controls/inline-edit/site.md
@@ -2,5 +2,6 @@
 layout: page-pattern
 overview: pattern-library/forms-and-controls/inline-edit/design/overview.md
 design: pattern-library/forms-and-controls/inline-edit/design/design.md
-code: false
+code_html: false
+impl_react: https://rawgit.com/patternfly/patternfly-react/gh-pages/index.html?&selectedKind=Table&selectedStory=Table%20With%20Inline%20Edit%20Row
 ---

--- a/pattern-library/forms-and-controls/modal-overlay/site.md
+++ b/pattern-library/forms-and-controls/modal-overlay/site.md
@@ -5,4 +5,5 @@ design: pattern-library/forms-and-controls/modal-overlay/design/design.md
 code_html: code/forms-and-controls/modal-overlay/code.md
 impl_jquery: https://rawgit.com/patternfly/patternfly/master-dist/dist/tests/modals.html
 impl_react: https://rawgit.com/patternfly/patternfly-react/gh-pages/index.html?knob-Right%20aligned=false&knob-fluid=true&knob-Stacked=false&selectedKind=Modal%20Overlay&selectedStory=Modal
+impl_angular: http://www.patternfly.org/angular-patternfly/#/api/patternfly.modals.componenet:pfModalOverlay
 ---

--- a/pattern-library/forms-and-controls/slider/site.md
+++ b/pattern-library/forms-and-controls/slider/site.md
@@ -4,4 +4,5 @@ overview: pattern-library/forms-and-controls/slider/design/overview.md
 design: pattern-library/forms-and-controls/slider/design/design.md
 code_html: code/forms-and-controls/slider/code.md
 impl_jquery: https://rawgit.com/patternfly/patternfly/master-dist/dist/tests/bootstrap-slider.html
+impl_react: https://rawgit.com/patternfly/patternfly-react/gh-pages/index.html?&selectedKind=Slider&selectedStory=Slider
 ---

--- a/pattern-library/navigation/pagination/site.md
+++ b/pattern-library/navigation/pagination/site.md
@@ -6,4 +6,5 @@ code_html: false
 impl_jquery: https://rawgit.com/patternfly/patternfly/master-dist/dist/tests/pagination.html
 impl_angular: https://www.patternfly.org/angular-patternfly/#/api/patternfly.pagination.component:pfPagination
 impl_ng: https://rawgit.com/patternfly/patternfly-ng/master-dist/dist-demo/#/pagination
+impl_react: https://rawgit.com/patternfly/patternfly-react/gh-pages/index.html?&selectedKind=Pagination&selectedStory=Pagination%20row
 ---


### PR DESCRIPTION
## Description
* This PR is to update the design status page and pf-org with framework links that have been recently merged 
* Related to this story/issue: https://github.com/patternfly/patternfly-org/issues/547

## Changes
* site.md is updated to show framework links

