### PR TITLE
chore(page title): Add unique titles for pattern Library pages

### DIFF
--- a/pattern-library/application-framework/launcher/site.md
+++ b/pattern-library/application-framework/launcher/site.md
@@ -1,4 +1,5 @@
 ---
+title: Launcher
 layout: page-pattern
 overview: pattern-library/application-framework/launcher/design/overview.md
 design: pattern-library/application-framework/launcher/design/design.md

--- a/pattern-library/application-framework/login-page/site.md
+++ b/pattern-library/application-framework/login-page/site.md
@@ -1,4 +1,5 @@
 ---
+title: Login Page
 layout: page-pattern
 overview: pattern-library/application-framework/login-page/design/overview.md
 design: pattern-library/application-framework/login-page/design/design.md

--- a/pattern-library/application-framework/masthead/site.md
+++ b/pattern-library/application-framework/masthead/site.md
@@ -1,4 +1,5 @@
 ---
+title: Masthead
 layout: page-pattern
 overview: pattern-library/application-framework/masthead/design/overview.md
 design: pattern-library/application-framework/masthead/design/design.md

--- a/pattern-library/application-framework/multi-factor-login/site.md
+++ b/pattern-library/application-framework/multi-factor-login/site.md
@@ -1,4 +1,5 @@
 ---
+title: Multi Factor Login
 layout: page-pattern
 overview: pattern-library/application-framework/multi-factor-login/design/overview.md
 design: pattern-library/application-framework/multi-factor-login/design/design.md

--- a/pattern-library/application-framework/single-sign-on/site.md
+++ b/pattern-library/application-framework/single-sign-on/site.md
@@ -1,4 +1,5 @@
 ---
+title: Single Sign On
 layout: page-pattern
 overview: pattern-library/application-framework/single-sign-on/design/overview.md
 design: pattern-library/application-framework/single-sign-on/design/design.md

--- a/pattern-library/cards/aggregate-status-card/site.md
+++ b/pattern-library/cards/aggregate-status-card/site.md
@@ -1,4 +1,5 @@
 ---
+title: Aggregate Status Card
 layout: page-pattern
 overview: pattern-library/cards/aggregate-status-card/design/overview.md
 design: pattern-library/cards/aggregate-status-card/design/design.md

--- a/pattern-library/cards/base-card/site.md
+++ b/pattern-library/cards/base-card/site.md
@@ -1,4 +1,5 @@
 ---
+title: Base Card
 layout: page-pattern
 overview: pattern-library/cards/base-card/design/overview.md
 design: pattern-library/cards/base-card/design/design.md

--- a/pattern-library/cards/trend-card/site.md
+++ b/pattern-library/cards/trend-card/site.md
@@ -1,4 +1,5 @@
 ---
+title: Trend Card
 layout: page-pattern
 overview: pattern-library/cards/trend-card/design/overview.md
 design: pattern-library/cards/trend-card/design/design.md

--- a/pattern-library/cards/utilization-bar-card/site.md
+++ b/pattern-library/cards/utilization-bar-card/site.md
@@ -1,4 +1,5 @@
 ---
+title: Utilization Bar Card
 layout: page-pattern
 overview: pattern-library/cards/utilization-bar-card/design/overview.md
 design: pattern-library/cards/utilization-bar-card/design/design.md

--- a/pattern-library/cards/utilization-trend-card/site.md
+++ b/pattern-library/cards/utilization-trend-card/site.md
@@ -1,4 +1,5 @@
 ---
+title: Utilization Trend Card
 layout: page-pattern
 overview: pattern-library/cards/utilization-trend-card/design/overview.md
 design: pattern-library/cards/utilization-trend-card/design/design.md

--- a/pattern-library/communication/about-modal/site.md
+++ b/pattern-library/communication/about-modal/site.md
@@ -1,4 +1,5 @@
 ---
+title: About Modal
 layout: page-pattern
 overview: pattern-library/communication/about-modal/design/overview.md
 design: pattern-library/communication/about-modal/design/design.md

--- a/pattern-library/communication/comments/site.md
+++ b/pattern-library/communication/comments/site.md
@@ -1,4 +1,5 @@
 ---
+title: Comments
 layout: page-pattern
 overview: pattern-library/communication/comments/design/overview.md
 design: pattern-library/communication/comments/design/design.md

--- a/pattern-library/communication/empty-state/site.md
+++ b/pattern-library/communication/empty-state/site.md
@@ -1,4 +1,5 @@
 ---
+title: Empty State
 layout: page-pattern
 overview: pattern-library/communication/empty-state/design/overview.md
 design: pattern-library/communication/empty-state/design/design.md

--- a/pattern-library/communication/experimental-features/site.md
+++ b/pattern-library/communication/experimental-features/site.md
@@ -1,4 +1,5 @@
 ---
+title: Experimental Features
 layout: page-pattern
 overview: pattern-library/communication/experimental-features/design/overview.md
 design: pattern-library/communication/experimental-features/design/design.md

--- a/pattern-library/communication/inline-notifications/site.md
+++ b/pattern-library/communication/inline-notifications/site.md
@@ -1,4 +1,5 @@
 ---
+title: Inline Notifications
 layout: page-pattern
 overview: pattern-library/communication/inline-notifications/design/overview.md
 design: pattern-library/communication/inline-notifications/design/design.md

--- a/pattern-library/communication/loading-state/site.md
+++ b/pattern-library/communication/loading-state/site.md
@@ -1,4 +1,5 @@
 ---
+title: Loading State
 layout: page-pattern
 overview: pattern-library/communication/loading-state/design/overview.md
 design: pattern-library/communication/loading-state/design/design.md

--- a/pattern-library/communication/notification-drawer/site.md
+++ b/pattern-library/communication/notification-drawer/site.md
@@ -1,5 +1,6 @@
 ---
 author: dlabrecq
+title: Notification Drawer
 layout: page-pattern
 overview: pattern-library/communication/notification-drawer/design/overview.md
 design: pattern-library/communication/notification-drawer/design/design.md

--- a/pattern-library/communication/session-timeout/site.md
+++ b/pattern-library/communication/session-timeout/site.md
@@ -1,4 +1,5 @@
 ---
+title: Session Timeout
 layout: page-pattern
 overview: pattern-library/communication/session-timeout/design/overview.md
 design: pattern-library/communication/session-timeout/design/design.md

--- a/pattern-library/communication/toast-notifications/site.md
+++ b/pattern-library/communication/toast-notifications/site.md
@@ -1,4 +1,5 @@
 ---
+title: Toast Notifications
 layout: page-pattern
 overview: pattern-library/communication/toast-notifications/design/overview.md
 design: pattern-library/communication/toast-notifications/design/design.md

--- a/pattern-library/communication/tour/site.md
+++ b/pattern-library/communication/tour/site.md
@@ -1,4 +1,5 @@
 ---
+title: Tour
 layout: page-pattern
 overview: pattern-library/communication/tour/design/overview.md
 design: pattern-library/communication/tour/design/design.md

--- a/pattern-library/communication/wizard/site.md
+++ b/pattern-library/communication/wizard/site.md
@@ -1,4 +1,5 @@
 ---
+title: Wizard
 layout: page-pattern
 overview: pattern-library/communication/wizard/design/overview.md
 design: pattern-library/communication/wizard/design/design.md

--- a/pattern-library/content-views/canvas-view/site.md
+++ b/pattern-library/content-views/canvas-view/site.md
@@ -1,4 +1,5 @@
 ---
+title: Canvas View
 layout: page-pattern
 overview: pattern-library/content-views/canvas-view/design/overview.md
 design: pattern-library/content-views/canvas-view/design/design.md

--- a/pattern-library/content-views/card-view/site.md
+++ b/pattern-library/content-views/card-view/site.md
@@ -1,4 +1,5 @@
 ---
+title: Card View
 layout: page-pattern
 overview: pattern-library/content-views/card-view/design/overview.md
 design: pattern-library/content-views/card-view/design/design.md

--- a/pattern-library/content-views/list-view/site.md
+++ b/pattern-library/content-views/list-view/site.md
@@ -1,4 +1,5 @@
 ---
+title: List View
 layout: page-pattern
 overview: pattern-library/content-views/list-view/design/overview.md
 design: pattern-library/content-views/list-view/design/design.md

--- a/pattern-library/content-views/table-view/site.md
+++ b/pattern-library/content-views/table-view/site.md
@@ -1,4 +1,5 @@
 ---
+title: Table View
 layout: page-pattern
 overview: pattern-library/content-views/table-view/design/overview.md
 design: pattern-library/content-views/table-view/design/design.md

--- a/pattern-library/content-views/tree-list-view/site.md
+++ b/pattern-library/content-views/tree-list-view/site.md
@@ -1,4 +1,5 @@
 ---
+title: Tree List View
 layout: page-pattern
 overview: pattern-library/content-views/tree-list-view/design/overview.md
 design: pattern-library/content-views/tree-list-view/design/design.md

--- a/pattern-library/dashboard/dashboard-layout/site.md
+++ b/pattern-library/dashboard/dashboard-layout/site.md
@@ -1,4 +1,5 @@
 ---
+title: Dashboard Layout
 layout: page-pattern
 overview: pattern-library/dashboard/dashboard-layout/design/overview.md
 design: pattern-library/dashboard/dashboard-layout/design/design.md

--- a/pattern-library/data-visualization/area-chart/site.md
+++ b/pattern-library/data-visualization/area-chart/site.md
@@ -1,4 +1,5 @@
 ---
+title: Area Chart
 layout: page-pattern
 overview: pattern-library/data-visualization/area-chart/design/overview.md
 design: pattern-library/data-visualization/area-chart/design/design.md

--- a/pattern-library/data-visualization/bar-chart/site.md
+++ b/pattern-library/data-visualization/bar-chart/site.md
@@ -1,4 +1,5 @@
 ---
+title: Bar Chart
 layout: page-pattern
 overview: pattern-library/data-visualization/bar-chart/design/overview.md
 design: pattern-library/data-visualization/bar-chart/design/design.md

--- a/pattern-library/data-visualization/bullet-chart/site.md
+++ b/pattern-library/data-visualization/bullet-chart/site.md
@@ -1,5 +1,6 @@
 ---
 author: lhinson
+title: Bullet Chart
 layout: page-pattern
 overview: pattern-library/data-visualization/bullet-chart/design/overview.md
 design: pattern-library/data-visualization/bullet-chart/design/design.md

--- a/pattern-library/data-visualization/donut-chart/site.md
+++ b/pattern-library/data-visualization/donut-chart/site.md
@@ -1,4 +1,5 @@
 ---
+title: Donut Chart
 layout: page-pattern
 overview: pattern-library/data-visualization/donut-chart/design/overview.md
 design: pattern-library/data-visualization/donut-chart/design/design.md

--- a/pattern-library/data-visualization/heat-map/site.md
+++ b/pattern-library/data-visualization/heat-map/site.md
@@ -1,5 +1,6 @@
 ---
 author: lhinson
+title: Heat Map
 layout: page-pattern
 overview: pattern-library/data-visualization/heat-map/design/overview.md
 design: pattern-library/data-visualization/heat-map/design/design.md

--- a/pattern-library/data-visualization/line-chart/site.md
+++ b/pattern-library/data-visualization/line-chart/site.md
@@ -1,4 +1,5 @@
 ---
+title: Line Chart
 layout: page-pattern
 overview: pattern-library/data-visualization/line-chart/design/overview.md
 design: pattern-library/data-visualization/line-chart/design/design.md

--- a/pattern-library/data-visualization/pie-chart/site.md
+++ b/pattern-library/data-visualization/pie-chart/site.md
@@ -1,4 +1,5 @@
 ---
+title: Pie Chart
 layout: page-pattern
 overview: pattern-library/data-visualization/pie-chart/design/overview.md
 design: pattern-library/data-visualization/pie-chart/design/design.md

--- a/pattern-library/data-visualization/sparkline/site.md
+++ b/pattern-library/data-visualization/sparkline/site.md
@@ -1,4 +1,5 @@
 ---
+title: Sparkline
 layout: page-pattern
 overview: pattern-library/data-visualization/sparkline/design/overview.md
 design: pattern-library/data-visualization/sparkline/design/design.md

--- a/pattern-library/data-visualization/timeline/site.md
+++ b/pattern-library/data-visualization/timeline/site.md
@@ -1,5 +1,6 @@
 ---
 author: lhinson
+title: Timeline
 layout: page-pattern
 overview: pattern-library/data-visualization/timeline/design/overview.md
 design: pattern-library/data-visualization/timeline/design/design.md

--- a/pattern-library/data-visualization/utilization-bar-chart/site.md
+++ b/pattern-library/data-visualization/utilization-bar-chart/site.md
@@ -1,4 +1,5 @@
 ---
+title: Utilization Bar Chart
 layout: page-pattern
 overview: pattern-library/data-visualization/utilization-bar-chart/design/overview.md
 design: pattern-library/data-visualization/utilization-bar-chart/design/design.md

--- a/pattern-library/forms-and-controls/buttons-on-forms/site.md
+++ b/pattern-library/forms-and-controls/buttons-on-forms/site.md
@@ -1,4 +1,5 @@
 ---
+title: Buttons on Forms
 layout: page-pattern
 overview: pattern-library/forms-and-controls/buttons-on-forms/design/overview.md
 design: pattern-library/forms-and-controls/buttons-on-forms/design/design.md

--- a/pattern-library/forms-and-controls/checkbox-filter/site.md
+++ b/pattern-library/forms-and-controls/checkbox-filter/site.md
@@ -1,4 +1,5 @@
 ---
+title: Checkbox Filter
 layout: page-pattern
 overview: pattern-library/forms-and-controls/checkbox-filter/design/overview.md
 design: pattern-library/forms-and-controls/checkbox-filter/design/design.md

--- a/pattern-library/forms-and-controls/data-input/site.md
+++ b/pattern-library/forms-and-controls/data-input/site.md
@@ -1,4 +1,5 @@
 ---
+title: Data Input
 layout: page-pattern
 overview: pattern-library/forms-and-controls/data-input/design/overview.md
 design: false

--- a/pattern-library/forms-and-controls/datepicker/site.md
+++ b/pattern-library/forms-and-controls/datepicker/site.md
@@ -1,4 +1,5 @@
 ---
+title: Datepicker
 layout: page-pattern
 overview: pattern-library/forms-and-controls/datepicker/design/overview.md
 design: pattern-library/forms-and-controls/datepicker/design/design.md

--- a/pattern-library/forms-and-controls/drag-and-drop/site.md
+++ b/pattern-library/forms-and-controls/drag-and-drop/site.md
@@ -1,4 +1,5 @@
 ---
+title: Drag and Drop
 layout: page-pattern
 overview: pattern-library/forms-and-controls/drag-and-drop/design/overview.md
 design: pattern-library/forms-and-controls/drag-and-drop/design/design.md

--- a/pattern-library/forms-and-controls/dual-list-selector/site.md
+++ b/pattern-library/forms-and-controls/dual-list-selector/site.md
@@ -1,4 +1,5 @@
 ---
+title: Dual List Selector
 layout: page-pattern
 overview: pattern-library/forms-and-controls/dual-list-selector/design/overview.md
 design: pattern-library/forms-and-controls/dual-list-selector/design/design.md

--- a/pattern-library/forms-and-controls/errors-and-validation/site.md
+++ b/pattern-library/forms-and-controls/errors-and-validation/site.md
@@ -1,5 +1,6 @@
 ---
 author: lhinson
+title: Errors and Validation
 layout: page-pattern
 overview: pattern-library/forms-and-controls/errors-and-validation/design/overview.md
 design: false

--- a/pattern-library/forms-and-controls/expand-collapse-section/site.md
+++ b/pattern-library/forms-and-controls/expand-collapse-section/site.md
@@ -1,5 +1,6 @@
 ---
 author: lhinson
+title: Expand Collapse Section
 layout: page-pattern
 overview: pattern-library/forms-and-controls/expand-collapse-section/design/overview.md
 design: pattern-library/forms-and-controls/expand-collapse-section/design/design.md

--- a/pattern-library/forms-and-controls/field-labeling/site.md
+++ b/pattern-library/forms-and-controls/field-labeling/site.md
@@ -1,4 +1,5 @@
 ---
+title: Field Labeling
 layout: page-pattern
 overview: pattern-library/forms-and-controls/field-labeling/design/overview.md
 design: pattern-library/forms-and-controls/field-labeling/design/design.md

--- a/pattern-library/forms-and-controls/filter/site.md
+++ b/pattern-library/forms-and-controls/filter/site.md
@@ -1,4 +1,5 @@
 ---
+title: Filter
 layout: page-pattern
 overview: pattern-library/forms-and-controls/filter/design/overview.md
 design: pattern-library/forms-and-controls/filter/design/design.md

--- a/pattern-library/forms-and-controls/find/site.md
+++ b/pattern-library/forms-and-controls/find/site.md
@@ -1,4 +1,5 @@
 ---
+title: Find
 layout: page-pattern
 overview: pattern-library/forms-and-controls/find/design/overview.md
 design: pattern-library/forms-and-controls/find/design/design.md

--- a/pattern-library/forms-and-controls/help-on-forms/site.md
+++ b/pattern-library/forms-and-controls/help-on-forms/site.md
@@ -1,4 +1,5 @@
 ---
+title: Help On Forms
 layout: page-pattern
 overview: pattern-library/forms-and-controls/help-on-forms/design/overview.md
 design: pattern-library/forms-and-controls/help-on-forms/design/design.md

--- a/pattern-library/forms-and-controls/inline-edit/site.md
+++ b/pattern-library/forms-and-controls/inline-edit/site.md
@@ -1,4 +1,5 @@
 ---
+title: Inline Edit
 layout: page-pattern
 overview: pattern-library/forms-and-controls/inline-edit/design/overview.md
 design: pattern-library/forms-and-controls/inline-edit/design/design.md

--- a/pattern-library/forms-and-controls/language-selector/site.md
+++ b/pattern-library/forms-and-controls/language-selector/site.md
@@ -1,4 +1,5 @@
 ---
+title: Language Selector
 layout: page-pattern
 overview: pattern-library/forms-and-controls/language-selector/design/overview.md
 design: pattern-library/forms-and-controls/language-selector/design/design.md

--- a/pattern-library/forms-and-controls/modal-overlay/site.md
+++ b/pattern-library/forms-and-controls/modal-overlay/site.md
@@ -1,4 +1,5 @@
 ---
+title: Modal Overlay
 layout: page-pattern
 overview: pattern-library/forms-and-controls/modal-overlay/design/overview.md
 design: pattern-library/forms-and-controls/modal-overlay/design/design.md

--- a/pattern-library/forms-and-controls/modeless-overlay/site.md
+++ b/pattern-library/forms-and-controls/modeless-overlay/site.md
@@ -1,4 +1,5 @@
 ---
+title: Modeless Overlay
 layout: page-pattern
 overview: pattern-library/forms-and-controls/modeless-overlay/design/overview.md
 design: pattern-library/forms-and-controls/modeless-overlay/design/design.md

--- a/pattern-library/forms-and-controls/progressive-disclosure/site.md
+++ b/pattern-library/forms-and-controls/progressive-disclosure/site.md
@@ -1,5 +1,6 @@
 ---
 author: lhinson
+title: Progressive Disclosure
 layout: page-pattern
 overview: pattern-library/forms-and-controls/progressive-disclosure/design/overview.md
 design: pattern-library/forms-and-controls/progressive-disclosure/design/design.md

--- a/pattern-library/forms-and-controls/slider/site.md
+++ b/pattern-library/forms-and-controls/slider/site.md
@@ -1,4 +1,5 @@
 ---
+title: Slider
 layout: page-pattern
 overview: pattern-library/forms-and-controls/slider/design/overview.md
 design: pattern-library/forms-and-controls/slider/design/design.md

--- a/pattern-library/forms-and-controls/sort/site.md
+++ b/pattern-library/forms-and-controls/sort/site.md
@@ -1,4 +1,5 @@
 ---
+title: Sort
 layout: page-pattern
 overview: pattern-library/forms-and-controls/sort/design/overview.md
 design: pattern-library/forms-and-controls/sort/design/design.md

--- a/pattern-library/forms-and-controls/textbox-filter/site.md
+++ b/pattern-library/forms-and-controls/textbox-filter/site.md
@@ -1,4 +1,5 @@
 ---
+title: Textbox Filter
 layout: page-pattern
 overview: pattern-library/forms-and-controls/textbox-filter/design/overview.md
 design: pattern-library/forms-and-controls/textbox-filter/design/design.md

--- a/pattern-library/forms-and-controls/toolbar/site.md
+++ b/pattern-library/forms-and-controls/toolbar/site.md
@@ -1,4 +1,5 @@
 ---
+title: Toolbar
 layout: page-pattern
 overview: pattern-library/forms-and-controls/toolbar/design/overview.md
 design: pattern-library/forms-and-controls/toolbar/design/design.md

--- a/pattern-library/forms-and-controls/view-selector/site.md
+++ b/pattern-library/forms-and-controls/view-selector/site.md
@@ -1,4 +1,5 @@
 ---
+title: View Selector
 layout: page-pattern
 overview: pattern-library/forms-and-controls/view-selector/design/overview.md
 design: pattern-library/forms-and-controls/view-selector/design/design.md

--- a/pattern-library/navigation/breadcrumbs/site.md
+++ b/pattern-library/navigation/breadcrumbs/site.md
@@ -1,4 +1,5 @@
 ---
+title: Breadcrumbs
 layout: page-pattern
 overview: pattern-library/navigation/breadcrumbs/design/overview.md
 design: pattern-library/navigation/breadcrumbs/design/design.md

--- a/pattern-library/navigation/context-selector/site.md
+++ b/pattern-library/navigation/context-selector/site.md
@@ -1,4 +1,5 @@
 ---
+title: Context Selector
 layout: page-pattern
 overview: pattern-library/navigation/context-selector/design/overview.md
 design: pattern-library/navigation/context-selector/design/design.md

--- a/pattern-library/navigation/pagination/site.md
+++ b/pattern-library/navigation/pagination/site.md
@@ -1,4 +1,5 @@
 ---
+title: Pagination
 layout: page-pattern
 overview: pattern-library/navigation/pagination/design/overview.md
 design: pattern-library/navigation/pagination/design/design.md


### PR DESCRIPTION
## Description
This PR is targeted to fix the [issue](https://github.com/patternfly/patternfly-org/issues/569)

## Changes

Write a list of changes this design pattern introduces

* Pages under "Pattern Library" section have their respective page title.

