### PR TITLE
Adding alert status icons

### DIFF
--- a/styles/icons/icons.json
+++ b/styles/icons/icons.json
@@ -66,9 +66,23 @@
     {
       "name": "fa-bell",
       "content": "f0f3",
-      "definition": "Notification",
-      "type": "Object",
-      "usage": "Used in masthead for Notification Drawer alerts/notifications"
+      "definition": "Notification/Firing",
+      "type": "Object/Status",
+      "usage": "Used in masthead for Notification Drawer alerts/notifications. Alternatively, indicates that an alert is currently firing"
+    },
+    {
+      "name": "fa-bell-o",
+      "content": "f0a2",
+      "definition": "Impending",
+      "type": "Status",
+      "usage": "Alert will fire soon"
+    },
+    {
+      "name": "fa-bell-slash",
+      "content": "f1f6",
+      "definition": "Silenced",
+      "type": "Status",
+      "usage": "Alert is silenced and will not fire"
     },
     {
       "name": "fa-bug",


### PR DESCRIPTION
## Description
Updates icon page to include several alert states. 

All icons draw from FontAwesome so no additional SVGs required.

## Changes
- Update fa-bell to include firing alert definition
- Add fa-bell-o for impending alert
- Add fa-bell-slash for silenced alert
